### PR TITLE
Experimental model

### DIFF
--- a/Summarizer/r3d_classifier.py
+++ b/Summarizer/r3d_classifier.py
@@ -1,0 +1,304 @@
+# Copied from TCLR
+
+import torch
+import torch.nn as nn
+# from torchvision.models.utils import load_state_dict_from_url
+# The following works for colab environments.
+from torch.hub import load_state_dict_from_url
+
+__all__ = ['r3d_18', 'mc3_18', 'r2plus1d_18']
+
+model_urls = {
+    'r3d_18': 'https://download.pytorch.org/models/r3d_18-b3b3357e.pth'
+}
+
+
+class Conv3DSimple(nn.Conv3d):
+    def __init__(self,
+                 in_planes,
+                 out_planes,
+                 midplanes=None,
+                 stride=1,
+                 padding=1):
+
+        super(Conv3DSimple, self).__init__(
+            in_channels=in_planes,
+            out_channels=out_planes,
+            kernel_size=(3, 3, 3),
+            stride=stride,
+            padding=padding,
+            bias=False)
+
+    @staticmethod
+    def get_downsample_stride(stride):
+        return (stride, stride, stride)
+
+
+class Conv2Plus1D(nn.Sequential):
+
+    def __init__(self,
+                 in_planes,
+                 out_planes,
+                 midplanes,
+                 stride=1,
+                 padding=1):
+        super(Conv2Plus1D, self).__init__(
+            nn.Conv3d(in_planes, midplanes, kernel_size=(1, 3, 3),
+                      stride=(1, stride, stride), padding=(0, padding, padding),
+                      bias=False),
+            nn.BatchNorm3d(midplanes),
+            nn.ReLU(inplace=True),
+            nn.Conv3d(midplanes, out_planes, kernel_size=(3, 1, 1),
+                      stride=(stride, 1, 1), padding=(padding, 0, 0),
+                      bias=False))
+
+    @staticmethod
+    def get_downsample_stride(stride):
+        return (stride, stride, stride)
+
+
+class Conv3DNoTemporal(nn.Conv3d):
+
+    def __init__(self,
+                 in_planes,
+                 out_planes,
+                 midplanes=None,
+                 stride=1,
+                 padding=1):
+
+        super(Conv3DNoTemporal, self).__init__(
+            in_channels=in_planes,
+            out_channels=out_planes,
+            kernel_size=(1, 3, 3),
+            stride=(1, stride, stride),
+            padding=(0, padding, padding),
+            bias=False)
+
+    @staticmethod
+    def get_downsample_stride(stride):
+        return (1, stride, stride)
+
+
+class BasicBlock(nn.Module):
+
+    expansion = 1
+
+    def __init__(self, inplanes, planes, conv_builder, stride=1, downsample=None):
+        midplanes = (inplanes * planes * 3 * 3 * 3) // (inplanes * 3 * 3 + 3 * planes)
+
+        super(BasicBlock, self).__init__()
+        self.conv1 = nn.Sequential(
+            conv_builder(inplanes, planes, midplanes, stride),
+            nn.BatchNorm3d(planes),
+            nn.ReLU(inplace=True)
+        )
+        self.conv2 = nn.Sequential(
+            conv_builder(planes, planes, midplanes),
+            nn.BatchNorm3d(planes)
+        )
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x):
+        residual = x
+
+        out = self.conv1(x)
+        out = self.conv2(out)
+        if self.downsample is not None:
+            residual = self.downsample(x)
+
+        out += residual
+        out = self.relu(out)
+
+        return out
+
+
+class Bottleneck(nn.Module):
+    expansion = 4
+
+    def __init__(self, inplanes, planes, conv_builder, stride=1, downsample=None):
+
+        super(Bottleneck, self).__init__()
+        midplanes = (inplanes * planes * 3 * 3 * 3) // (inplanes * 3 * 3 + 3 * planes)
+
+        # 1x1x1
+        self.conv1 = nn.Sequential(
+            nn.Conv3d(inplanes, planes, kernel_size=1, bias=False),
+            nn.BatchNorm3d(planes),
+            nn.ReLU(inplace=True)
+        )
+        # Second kernel
+        self.conv2 = nn.Sequential(
+            conv_builder(planes, planes, midplanes, stride),
+            nn.BatchNorm3d(planes),
+            nn.ReLU(inplace=True)
+        )
+
+        # 1x1x1
+        self.conv3 = nn.Sequential(
+            nn.Conv3d(planes, planes * self.expansion, kernel_size=1, bias=False),
+            nn.BatchNorm3d(planes * self.expansion)
+        )
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x):
+        residual = x
+
+        out = self.conv1(x)
+        out = self.conv2(out)
+        out = self.conv3(out)
+
+        if self.downsample is not None:
+            residual = self.downsample(x)
+
+        out += residual
+        out = self.relu(out)
+
+        return out
+
+
+class BasicStem(nn.Sequential):
+    """The default conv-batchnorm-relu stem
+    """
+    def __init__(self):
+        super(BasicStem, self).__init__(
+            nn.Conv3d(3, 64, kernel_size=(3, 7, 7), stride=(1, 2, 2),
+                      padding=(1, 3, 3), bias=False),
+            nn.BatchNorm3d(64),
+            nn.ReLU(inplace=True))
+
+
+class R2Plus1dStem(nn.Sequential):
+    """R(2+1)D stem is different than the default one as it uses separated 3D convolution
+    """
+    def __init__(self):
+        super(R2Plus1dStem, self).__init__(
+            nn.Conv3d(3, 45, kernel_size=(1, 7, 7),
+                      stride=(1, 2, 2), padding=(0, 3, 3),
+                      bias=False),
+            nn.BatchNorm3d(45),
+            nn.ReLU(inplace=True),
+            nn.Conv3d(45, 64, kernel_size=(3, 1, 1),
+                      stride=(1, 1, 1), padding=(1, 0, 0),
+                      bias=False),
+            nn.BatchNorm3d(64),
+            nn.ReLU(inplace=True))
+
+
+class VideoResNet(nn.Module):
+
+    def __init__(self, block, conv_makers, layers,
+                 stem, num_classes=400,
+                 zero_init_residual=False):
+        """Generic resnet video generator.
+
+        Args:
+            block (nn.Module): resnet building block
+            conv_makers (list(functions)): generator function for each layer
+            layers (List[int]): number of blocks per layer
+            stem (nn.Module, optional): Resnet stem, if None, defaults to conv-bn-relu. Defaults to None.
+            num_classes (int, optional): Dimension of the final FC layer. Defaults to 400.
+            zero_init_residual (bool, optional): Zero init bottleneck residual BN. Defaults to False.
+        """
+        super(VideoResNet, self).__init__()
+        self.inplanes = 64
+
+        self.stem = stem()
+
+        self.layer1 = self._make_layer(block, conv_makers[0], 64, layers[0], stride=1)
+        self.layer2 = self._make_layer(block, conv_makers[1], 128, layers[1], stride=2)
+        self.layer3 = self._make_layer(block, conv_makers[2], 256, layers[2], stride=2)
+        self.layer4 = self._make_layer(block, conv_makers[3], 512, layers[3], stride=2)
+
+        self.avgpool = nn.AdaptiveAvgPool3d((None, 1, 1))
+        # self.avgpool = nn.AvgPool3d(kernel_size = (1, 3, 3), stride = (1, 2, 2)) # This can be made adaptive avg for different input size
+        self.fc = nn.Linear(512 * block.expansion, num_classes)
+
+        # init weights
+        self._initialize_weights()
+
+        if zero_init_residual:
+            for m in self.modules():
+                if isinstance(m, Bottleneck):
+                    nn.init.constant_(m.bn3.weight, 0)
+
+    def forward(self, x):
+        x = self.stem(x)
+
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+
+        x = self.avgpool(x)
+        # # Flatten the layer to fc
+        # x = x.flatten(1)
+        # x = self.fc(x)
+
+        return x
+
+    def _make_layer(self, block, conv_builder, planes, blocks, stride=1):
+        downsample = None
+
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            ds_stride = conv_builder.get_downsample_stride(stride)
+            downsample = nn.Sequential(
+                nn.Conv3d(self.inplanes, planes * block.expansion,
+                          kernel_size=1, stride=ds_stride, bias=False),
+                nn.BatchNorm3d(planes * block.expansion)
+            )
+        layers = []
+        layers.append(block(self.inplanes, planes, conv_builder, stride, downsample))
+
+        self.inplanes = planes * block.expansion
+        for i in range(1, blocks):
+            layers.append(block(self.inplanes, planes, conv_builder))
+
+        return nn.Sequential(*layers)
+
+    def _initialize_weights(self):
+        for m in self.modules():
+            if isinstance(m, nn.Conv3d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out',
+                                        nonlinearity='relu')
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.BatchNorm3d):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.Linear):
+                nn.init.normal_(m.weight, 0, 0.01)
+                nn.init.constant_(m.bias, 0)
+
+
+def _video_resnet(arch, pretrained=False, progress=True, **kwargs):
+    model = VideoResNet(**kwargs)
+
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls[arch],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+    return model
+
+
+def r3d_18_classifier(pretrained=False, progress=True, **kwargs):
+    """Construct 18 layer Resnet3D model as in
+    https://arxiv.org/abs/1711.11248
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on Kinetics-400
+        progress (bool): If True, displays a progress bar of the download to stderr
+
+    Returns:
+        nn.Module: R3D-18 network
+    """
+
+    return _video_resnet('r3d_18',
+                         pretrained, progress,
+                         block=BasicBlock,
+                         conv_makers=[Conv3DSimple] * 4,
+                         layers=[2, 2, 2, 2],
+                         stem=BasicStem, **kwargs)

--- a/Summarizer/summarizer_dataset.py
+++ b/Summarizer/summarizer_dataset.py
@@ -279,6 +279,8 @@ class Summarizer_Dataset(Dataset):
             
             
             # Return the next data sample.
+            # [S, F, H, W, C] -> [S, F, C, H, W]
+            segments = segments.permute(0, 1, 4, 2, 3)
             if self.is_video_only:
                 return {
                     "segments": segments,

--- a/Summarizer/summarizer_dataset.py
+++ b/Summarizer/summarizer_dataset.py
@@ -279,8 +279,8 @@ class Summarizer_Dataset(Dataset):
             
             
             # Return the next data sample.
-            # [S, F, H, W, C] -> [S, F, C, H, W]
-            segments = segments.permute(0, 1, 4, 2, 3)
+            # [S, F, H, W, C] -> [S, C, F, H, W]
+            segments = segments.permute(0, 4, 2, 3)
             if self.is_video_only:
                 return {
                     "segments": segments,

--- a/Summarizer/transformer_model.py
+++ b/Summarizer/transformer_model.py
@@ -1,0 +1,169 @@
+
+import math
+import os
+import re
+from turtle import forward
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torchsummary import summary
+from torch.cuda.amp import autocast
+
+from Summarizer import r3d_classifier as r3d
+
+class mlp(nn.Module):
+
+    def __init__(self, final_embedding_size=128, use_normalization=True):
+        
+        super(mlp, self).__init__()
+
+        self.final_embedding_size = final_embedding_size
+        self.use_normalization = use_normalization
+        self.fc1 = nn.Linear(512,512, bias = True)
+        self.bn1 = nn.BatchNorm1d(512)
+        self.bn2 = nn.BatchNorm1d(final_embedding_size)
+
+        self.relu = nn.ReLU(inplace=True)
+        self.fc2 = nn.Linear(512, self.final_embedding_size, bias = False)
+        self.temp_avg = nn.AdaptiveAvgPool3d((1,None,None))
+
+    def forward(self, x):
+        if torch.cuda.is_available():
+            with autocast(): # only works with gpu
+                x = self.temp_avg(x)                    # [B x 512 x 4 x 1 x 1] -> [B x 512 x 1 x 1 x 1]
+                x = x.flatten(1)                        # [B x 512 x 1 x 1 x 1] -> [B x 512]
+                x = self.relu(self.bn1(self.fc1(x)))
+                x = nn.functional.normalize(self.bn2(self.fc2(x)), p=2, dim=1)
+                return x
+        else:
+            x = self.temp_avg(x)
+            x = x.flatten(1)
+            x = self.relu(self.bn1(self.fc1(x)))
+            x = nn.functional.normalize(self.bn2(self.fc2(x)), p=2, dim=1)
+            return x
+
+def load_tclr_backbone(saved_model_file: str = None, d_output: int = 128):
+    model = r3d.r3d_18_classifier(pretrained=False, progress=False)
+    # TCLR modifications from R3d.
+    model.layer4[0].conv1[0] = nn.Conv3d(256, 512, kernel_size=(3, 3, 3),\
+                                stride=(1, 2, 2), padding=(2, 1, 1),dilation = (2,1,1), bias=False)
+    model.layer4[0].downsample[0] = nn.Conv3d(256, 512,\
+                          kernel_size = (1, 1, 1), stride = (1, 2, 2), bias=False)
+
+    # Weight copying.
+    pretrained = None
+    if torch.cuda.is_available():
+        pretrained = torch.load(saved_model_file)
+    else:
+        pretrained = torch.load(saved_model_file, map_location=torch.device('cpu'))
+    pretrained_kvpair = pretrained['state_dict']
+    model_kvpair = model.state_dict()
+    for layer_name, weights in pretrained_kvpair.items():
+        if 'module.1.' in layer_name:
+            continue              
+        elif '1.' == layer_name[:2]:
+            continue
+        if 'module.0.' in layer_name:
+            layer_name = layer_name.replace('module.0.','')
+        if 'module.' in layer_name:
+            layer_name = layer_name.replace('module.','')
+        elif '0.' == layer_name[:2]:
+            layer_name = layer_name[2:]
+        model_kvpair[layer_name] = weights   
+    model.load_state_dict(model_kvpair, strict=True)
+    print(f'model {saved_model_file} loaded successsfully!')
+    
+    # Added for Summarization.
+    model.fc = nn.Linear(512, d_output, bias=False)
+    return model
+
+
+class PositionalEncoding(nn.Module):
+    def __init__(self, d_model, dropout=0.1, max_len=5000):
+        super(PositionalEncoding, self).__init__()
+        self.dropout = nn.Dropout(p=dropout)
+
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0).transpose(0, 1)
+        self.register_buffer("pe", pe)
+
+    def forward(self, x):
+        x = x + self.pe[: x.size(0), :]
+        return self.dropout(x)
+
+
+class TCLRSummarizer(nn.Module):
+
+    def __init__(self, saved_model_file: str, d_model: int = 128, freeze_base: bool = True, 
+        heads: int = 8, enc_layers: int = 6, dropout: float = 0.1) -> None:
+        """
+        d_model determines the output embedding dimensionality.
+        """
+        super(TCLRSummarizer, self).__init__()
+
+        # NOTE: model expects expects [B x C x S x H x W] = [nsegments, nchannels, nframes_per_segments, size, size]
+        self.base_model = load_tclr_backbone(saved_model_file, d_output=d_model)
+        if freeze_base:
+            # Freezes all layers except the last.
+            for param in self.base_model.parameters():
+                param.requires_grad = False
+            self.base_model.fc.requires_grad = True
+
+        self.d_model = d_model
+        self.mlp = mlp(final_embedding_size=d_model)
+        self.pos_enc = PositionalEncoding(self.d_model, dropout)
+        encoder_layers = nn.TransformerEncoderLayer(
+            d_model=self.d_model, nhead=heads, dropout=dropout
+        )
+        self.transformer_encoder = nn.TransformerEncoder(
+            encoder_layers, num_layers=enc_layers
+        )
+        self.fc = nn.Linear(self.d_model, 1)
+
+    def forward(self, video):
+        # [n_segs, C, S, H, W] -> [n_segs x d_output x 4 x 1 x 1] --> [n_segs x d_output]
+        video_emb = nn.Sequential(self.base_model, self.mlp)(video)
+        
+        # [n_segs, d_model] -> [1, n_segs, d_model]
+        video_emb = video_emb.unsqueeze(0)
+        video_emb = self.pos_enc(video_emb)  # Add pos enc as nn.Trasnformer doesnt have it
+        
+        video_emb = self.transformer_encoder(video_emb)
+        video_emb = video_emb.contiguous().view(-1, self.d_model)
+        logits = self.fc(video_emb)
+        return video_emb, logits
+    
+def print_param_size(model_state_dict):
+    for param_tensor in model_state_dict:
+        print(param_tensor, "\t",model_state_dict[param_tensor].size())       
+
+
+if __name__ == '__main__':
+    # Test with `python -i -m Summarizer.model`.
+
+    SAVED_MODEL_FILE = "/home/derekhmd/atv_summe_20221127_model_temp.pth"
+    # print("Loading Manually")
+    # model = torch.load(SAVED_MODEL_FILE, map_location=torch.device('cpu'))
+    # model_state_dict = model['state_dict']
+    # print_param_size(model_state_dict)
+
+
+    print("Loading TCLR Backbone")
+    tclr = load_tclr_backbone(SAVED_MODEL_FILE)
+    summtclr1 = TCLRSummarizer(SAVED_MODEL_FILE, d_model=128)
+    summtclr2 = TCLRSummarizer(SAVED_MODEL_FILE, d_model=256)
+    summtclr5 = TCLRSummarizer(SAVED_MODEL_FILE, d_model=512)
+
+    x = torch.rand(10, 3, 16, 112, 112) # 10 segments of 16 frames 3 x 112 x 112
+    e = tclr(x)
+    emb1, logits1 = summtclr1(x)
+    emb2, logits2 = summtclr2(x)
+    emb5, logits5 = summtclr5(x)


### PR DESCRIPTION
I noticed that pull 6 (https://github.com/derkmed/cs6998_05/pull/6) relies on only a single Multi-head attention block as opposed to a transformer for frame scoring. Furthermore, the default TCLR backbone doesn't actually return a 512 x 1 vector as desired. See Fig. 4 and Sec. 3.2.2. of https://www.sciencedirect.com/science/article/pii/S1077314222000376?via%3Dihub .